### PR TITLE
Fix variable typo in Weibull stats

### DIFF
--- a/exponential_and_weibull_distribution.ipynb
+++ b/exponential_and_weibull_distribution.ipynb
@@ -178,12 +178,12 @@
         "\n",
         "# Основні характеристики: математичне сподівання; дисперсія, стандартне відхилення\n",
         "mean_random = np.mean(random_numbers)\n",
-        "variance_randowm = np.var(random_numbers, ddof=1)\n",
+        "variance_random = np.var(random_numbers, ddof=1)\n",
         "std_random = np.std(random_numbers, ddof=1)\n",
         "print(f\"\"\"\n",
         "Математичне сподівання: {mean_random}\n",
-        "Дисперсія: {variance_randowm}\n",
-        "Сатндратне відхилення: {std_random}\n",
+        "Дисперсія: {variance_random}\n",
+        "Стандартне відхилення: {std_random}\n",
         "\"\"\")"
       ],
       "metadata": {
@@ -202,7 +202,7 @@
             "\n",
             "Математичне сподівання: 18.5\n",
             "Дисперсія: 47.388888888888886\n",
-            "Сатндратне відхилення: 6.883958809354461      \n",
+            "Стандартне відхилення: 6.883958809354461      \n",
             "\n"
           ]
         }


### PR DESCRIPTION
## Summary
- fix `variance_randowm` typo in `exponential_and_weibull_distribution.ipynb`
- correct typo in printed text

## Testing
- `python3 -m json.tool exponential_and_weibull_distribution.ipynb > /dev/null && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_68404c86d93c8327947686286b18e30e