### PR TITLE
Fix variable name typos

### DIFF
--- a/definition_distribution_law.ipynb
+++ b/definition_distribution_law.ipynb
@@ -44,7 +44,7 @@
             "\n",
             "hist, bin_edges = (array([2, 4, 4, 4, 2]), array([0.8 , 1.32, 1.84, 2.36, 2.88, 3.4 ]))\n",
             "\n",
-            "cass_centers = ([0.8  1.32 1.84 2.36 2.88] + [1.32 1.84 2.36 2.88 3.4 ]) / 2\n",
+            "class_centers = ([0.8  1.32 1.84 2.36 2.88] + [1.32 1.84 2.36 2.88 3.4 ]) / 2\n",
             "\n"
           ]
         }
@@ -62,7 +62,7 @@
         "\n",
         "print(f\"\"\"\n",
         "hist, bin_edges = {np.histogram(x2, bins=n_classes)}\n",
-        "\\ncass_centers = ({bin_edges[:-1]} + {bin_edges[1:]}) / 2\n",
+        "\\nclass_centers = ({bin_edges[:-1]} + {bin_edges[1:]}) / 2\n",
         "\"\"\")"
       ]
     },

--- a/lab3_definition_distribution_law.ipynb
+++ b/lab3_definition_distribution_law.ipynb
@@ -59,7 +59,7 @@
             "\n",
             "hist, bin_edges = (array([3, 0, 1, 1, 3]), array([ 2.11 , 20.132, 38.154, 56.176, 74.198, 92.22 ]))\n",
             "\n",
-            "cass_centers = ([ 2.11  20.132 38.154 56.176 74.198] + [20.132 38.154 56.176 74.198 92.22 ]) / 2\n",
+            "class_centers = ([ 2.11  20.132 38.154 56.176 74.198] + [20.132 38.154 56.176 74.198 92.22 ]) / 2\n",
             "\n"
           ]
         }
@@ -73,7 +73,7 @@
         "\n",
         "print(f\"\"\"\n",
         "hist, bin_edges = {np.histogram(x2, bins=n_classes)}\n",
-        "\\ncass_centers = ({bin_edges[:-1]} + {bin_edges[1:]}) / 2\n",
+        "\\nclass_centers = ({bin_edges[:-1]} + {bin_edges[1:]}) / 2\n",
         "\"\"\")"
       ]
     },


### PR DESCRIPTION
## Summary
- rename `cass_centers` to `class_centers` in notebooks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404e7b34208327bb8838debe9dbe04